### PR TITLE
[feat] python3.8も対応する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ EXP_TASKS := $(addprefix exp_, $(TASKS))
 # すべての通常タスクを実行
 all: $(TASKS)
 
+all_exp: $(EXP_TASKS)
+
 # 変数で eps を管理
 correct_eps_noisy_sum := 0.1
 adj_noisy_sum := inf

--- a/dpest/distrib.py
+++ b/dpest/distrib.py
@@ -3,6 +3,7 @@ import numpy as np
 from . import Pmf
 from dpest.config import *
 from dpest.input import ArrayItem
+from typing import Union
 
 class HistPmf(Pmf):
     # histは二次元配列で、要素があるところに1が立つ
@@ -15,7 +16,7 @@ class RawPmf(Pmf):
         self.name = "RawPmf"
 
 class Laplace(Pmf):
-    def __init__(self, mu: float | ArrayItem, b: float):
+    def __init__(self, mu: Union[float, ArrayItem], b: float):
         super().__init__()
         self.child = [mu]
         self.b = b
@@ -36,7 +37,7 @@ class Laplace(Pmf):
         
 
 class Exp(Pmf):
-    def __init__(self, mu: float | ArrayItem, b: float):
+    def __init__(self, mu: Union[float, ArrayItem], b: float):
         super().__init__()
         self.child = [mu]
         self.b = b

--- a/dpest/operation.py
+++ b/dpest/operation.py
@@ -8,20 +8,21 @@ from utils.pr_calc import nonuniform_convolution
 from . import Pmf
 from dpest.config import *
 from dpest.distrib import RawPmf
+from typing import Union
 
 class Add(Pmf):
     """
     二つの確率変数同士を足すクラス
     """
     def __init__(self, var1: Pmf, var2: Pmf):
-        assert isinstance(var1, Pmf) & isinstance(var2, Pmf | int | float)
+        assert isinstance(var1, Pmf) & isinstance(var2, (Pmf, int, float))
         super().__init__()
         self.child = [var1, var2]
         if isinstance(var2, Pmf):
             self.name = f"Add({var1.name}, {var2.name})"
             self.is_args_depend = len(set(var1.depend_vars) & set(var2.depend_vars)) > 0
             self.depend_vars = list(set(var1.depend_vars) | set(var2.depend_vars))
-        elif isinstance(var2, int | float):
+        elif isinstance(var2, (int, float)):
             self.name = f"Add({var1.name}, {var2})"
             self.is_args_depend = False
             self.depend_vars = var1.depend_vars
@@ -35,7 +36,7 @@ class Add(Pmf):
         """
         引数から出力の確率密度を厳密に計算する
         """
-        if isinstance(child[1], int | float):
+        if isinstance(child[1], Union(int, float)):
             val1, pdf1 = list(child[0].val_to_prob.keys()), list(child[0].val_to_prob.values())
             output_val1 = [v + child[1] for v in val1]
             return RawPmf(dict(zip(output_val1, pdf1)))
@@ -115,7 +116,7 @@ class Br(Pmf):
     二つの確率変数または、一つの確率変数と定数を引数に取り、その大小関係に応じて、確率変数や定数を返す
     Compクラスを包含するクラス
     """
-    def __init__(self, input_var1: Pmf, input_var2: Pmf | int | float, output_var1: Pmf | int | float, output_var2: Pmf | int | float):
+    def __init__(self, input_var1: Pmf, input_var2: Union[Pmf, int, float], output_var1: Union[Pmf, int, float], output_var2: Union[Pmf, int, float]):
         # assert isinstance(input_var1, Pmf) & isinstance(input_var2, Pmf | int | float)
         super().__init__()
         self.child = [input_var1, input_var2, output_var1, output_var2]
@@ -134,7 +135,7 @@ class Br(Pmf):
     def calc_pdf(self, children):
         assert len(children) == 4
         input_var1, input_var2, output_var1, output_var2 = children
-        assert isinstance(input_var1, Pmf) & isinstance(input_var2, Pmf | int | float) & isinstance(output_var1, Pmf | int | float) & isinstance(output_var2, Pmf | int | float)
+        assert isinstance(input_var1, Pmf) & isinstance(input_var2, (Pmf, int, float)) & isinstance(output_var1, (Pmf, int, float)) & isinstance(output_var2, (Pmf, int, float))
         raise NotImplementedError # Brを用いて解析的に計算するアルゴリズムがないので未実装
     
     def func(self, args: list):
@@ -152,8 +153,8 @@ class Comp(Pmf):
     引数に定数を取るとしたら、第二引数に定数を取るようにする
     e.g. Comp(pmf, const) or Comp(pmf1, pmf2)
     """
-    def __init__(self, var1: Pmf, var2: Pmf | int | float):
-        assert isinstance(var1, Pmf) & isinstance(var2, Pmf | int | float)
+    def __init__(self, var1: Pmf, var2: Union[Pmf, int, float]):
+        assert isinstance(var1, Pmf) & isinstance(var2, (Pmf, int, float))
         super().__init__()
         self.child = [var1, var2]
         self.name = f"Comp({var1.name}, {var2.name})"
@@ -165,8 +166,8 @@ class Comp(Pmf):
         child1, child2 = children
 
         # 片方がArrayItemという定数
-        if isinstance(child1, int | float) or isinstance(child2, int | float):
-            const, pmf = child1, child2 if isinstance(child1, int | float) else child2, child1
+        if isinstance(child1, Union[int, float]) or isinstance(child2, (int, float)):
+            const, pmf = child1, child2 if isinstance(child1, (int, float)) else child2, child1
             val = list(pmf.val_to_prob.keys())
             pdf = list(pmf.val_to_prob.values())
             f = interpolate.CubicSpline(val, pdf, bc_type='natural', extrapolate=True)
@@ -202,15 +203,15 @@ class Comp(Pmf):
 確率変数を1つ引数に取り、特定の定数に等しい場合に、特定の値や確率変数を返す
 """
 class Case(Pmf):
-    def __new__(cls, var: Pmf | int | float = None, case_dict: dict = None):
-        if isinstance(var, int | float):
+    def __new__(cls, var: Union[Pmf, int, float] = None, case_dict: dict = None):
+        if isinstance(var, (int, float)):
             if case_dict.get(var) is None:
                 if case_dict.get("otherwise") is None:
                     raise ValueError("Invalid Case")
                 return case_dict["otherwise"]
             return case_dict[var]
         return super().__new__(cls)
-    def __init__(self, var: Pmf | int | float, case_dict: dict):
+    def __init__(self, var: Union[Pmf, int, float], case_dict: dict):
         assert isinstance(var, Pmf)
         super().__init__()
         case_dict_instance = CaseDict(case_dict)
@@ -247,12 +248,12 @@ class Case(Pmf):
                     assert list(self.child[1].case_dict.keys())[-1] == "otherwise"
                     case_val_prob = 1 - sum(output_dict.values())
                 else:
-                    assert isinstance(case_val, int | float | np.int64 | np.float64)
+                    assert isinstance(case_val, (int, float, np.int64, np.float64))
                     case_val_prob = child.val_to_prob[case_val]
                 sum_case_val_prob += case_val_prob
                 assert sum_case_val_prob <= 1
 
-                if isinstance(case_var, int | float):
+                if isinstance(case_var, (int, float)):
                     if output_dict.get(case_var) is None:
                         output_dict[case_var] = case_val_prob
                     else:
@@ -277,7 +278,7 @@ class Case(Pmf):
         assert len(args) == 2
         val = args[0]
         case_dict = args[1]
-        assert isinstance(val, int | float | np.int64 | np.float64 ) & isinstance(case_dict, dict)
+        assert isinstance(val, (int, float, np.int64, np.float64)) & isinstance(case_dict, dict)
         if case_dict.get(val) is None:
             if case_dict.get("otherwise") is None:
                 raise ValueError("Invalid Case")

--- a/dpest/operation.py
+++ b/dpest/operation.py
@@ -36,7 +36,7 @@ class Add(Pmf):
         """
         引数から出力の確率密度を厳密に計算する
         """
-        if isinstance(child[1], Union(int, float)):
+        if isinstance(child[1], (int, float)):
             val1, pdf1 = list(child[0].val_to_prob.keys()), list(child[0].val_to_prob.values())
             output_val1 = [v + child[1] for v in val1]
             return RawPmf(dict(zip(output_val1, pdf1)))
@@ -166,7 +166,7 @@ class Comp(Pmf):
         child1, child2 = children
 
         # 片方がArrayItemという定数
-        if isinstance(child1, Union[int, float]) or isinstance(child2, (int, float)):
+        if isinstance(child1, (int, float)) or isinstance(child2, (int, float)):
             const, pmf = child1, child2 if isinstance(child1, (int, float)) else child2, child1
             val = list(pmf.val_to_prob.keys())
             pdf = list(pmf.val_to_prob.values())

--- a/dpest/run_graph.py
+++ b/dpest/run_graph.py
@@ -5,9 +5,10 @@ from dpest.operation import Case, Br
 from dpest.distrib import Laplace, Exp, ArrayItem, HistPmf, RawPmf, Uni
 from dpest.input import InputScalarToArrayItem
 from dpest.config import *
+from typing import Union
 
 def input_analysis_rec(var, size, adj):
-    if isinstance(var, Uni | int | float | np.float64 | np.int64 | int | str):
+    if isinstance(var, (Uni, int, float, np.float64, np.int64, int, str)):
         return size, adj
     if isinstance(var, ArrayItem):
         if size == 0:
@@ -24,9 +25,9 @@ def input_analysis_rec(var, size, adj):
     return size, adj
 
 def insert_input_rec(var1, var2, input_val_list1, input_val_list2):
-    if isinstance(var1, Laplace | Exp):
+    if isinstance(var1, (Laplace, Exp)):
         assert len(var1.child) == 1
-        if isinstance(var1.child[0], int | float):
+        if isinstance(var1.child[0], (int, float)):
             return var1, var2
         elif isinstance(var1.child[0], ArrayItem):
             var1.child[0] = input_val_list1[var1.child[0].ind]
@@ -79,7 +80,7 @@ def insert_input_rec(var1, var2, input_val_list1, input_val_list2):
     return var1, var2
 
 def resolve_dependency_rec(var1, var2): # var1とvar2はLaplaceの確率密度以外は同じことを前提とする
-    if isinstance(var1, Laplace | Exp | RawPmf | HistPmf | Uni | np.float64 | np.int64 | int | str):
+    if isinstance(var1, (Laplace, Exp, RawPmf, HistPmf, Uni, np.float64, np.int64, int, str)):
         return var1, var2
     if var1.is_args_depend:
         # ここでサンプリングにより確率密度を計算する
@@ -95,7 +96,7 @@ def resolve_dependency_rec(var1, var2): # var1とvar2はLaplaceの確率密度�
     return var1, var2
 
 def calc_pdf_rec(var):
-    if isinstance(var, Laplace | Exp | Uni | RawPmf | HistPmf | np.float64 | np.int64 | int):
+    if isinstance(var, (Laplace, Exp, Uni, RawPmf, HistPmf, np.float64, np.int64, int)):
         return var
     output_var = var.calc_pdf([calc_pdf_rec(child) for child in var.child])
     return output_var
@@ -106,12 +107,12 @@ def calc_pdf_by_sampling(var1, var2):
     """
     # sampling_val_memoはサンプリングした値を記録するための辞書
     def _calc_pdf_by_sampling_rec(var1, var2, sampling_val_memo: dict): # var1とvar2はLaplaceの確率密度以外は同じことを前提とする
-        if isinstance(var1, float | int | np.float64 | np.int64 | str):
+        if isinstance(var1, (float, int, np.float64, np.int64, str)):
             return var1, var2
         elif sampling_val_memo.get(var1) is not None:
             return sampling_val_memo[var1], sampling_val_memo[var2]
-        elif isinstance(var1, Laplace | Exp):
-            if isinstance(var1.child[0], int | float):
+        elif isinstance(var1, (Laplace, Exp)):
+            if isinstance(var1.child[0], (int, float)):
                 lap_sample1, lap_sample2 = var1.sampling(), var2.sampling()
                 sampling_val_memo[var1], sampling_val_memo[var2] = lap_sample1, lap_sample2
                 return lap_sample1, lap_sample2
@@ -135,7 +136,7 @@ def calc_pdf_by_sampling(var1, var2):
     output_type = type(one_sample)
 
     # εを求めるためのサンプリング
-    if isinstance(one_sample, int | np.int64 | float | np.float64):
+    if isinstance(one_sample, (int, np.int64, float, np.float64)):
         # 最小値と最大値を求めるためのサンプリング
         test_samples = 200
         samples = np.empty(test_samples, dtype=output_type)
@@ -153,7 +154,7 @@ def calc_pdf_by_sampling(var1, var2):
         outputs1 = np.asarray(outputs1)
         outputs2 = np.asarray(outputs2)
         # 出力が整数値の場合は、それぞれ整数値ごとにヒストグラムを作成する
-        if isinstance(samples[0], np.int64 | int):
+        if isinstance(samples[0], (np.int64, int)):
             # 整数値ごとのヒストグラムを作る際には、このように+2する必要がある
             hist_range = np.arange(min_vals, max_vals + 2)
             hist1, edges1 = np.histogram(outputs1, bins=hist_range)
@@ -163,7 +164,7 @@ def calc_pdf_by_sampling(var1, var2):
             hist1, edges1 = np.histogram(outputs1, bins=GRID_NUM, range=hist_range)
             hist2, edges2 = np.histogram(outputs2, bins=GRID_NUM, range=hist_range)
         return HistPmf(hist1), HistPmf(hist2)
-    elif isinstance(one_sample, np.ndarray | list):
+    elif isinstance(one_sample, (np.ndarray, list)):
         # 最小値と最大値を求めるためのサンプリング
         test_samples = 200
         samples = np.empty(test_samples, dtype=object)
@@ -178,7 +179,7 @@ def calc_pdf_by_sampling(var1, var2):
                     type_set.add(np.nan)
                 elif isinstance(scalar, bool):
                     type_set.add(bool)
-                elif isinstance(scalar, int | np.int64):
+                elif isinstance(scalar, (int, np.int64)):
                     type_set.add(int)
                 elif isinstance(scalar, float | np.float64):
                     float_max = max(float_max, scalar)

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,5 @@ setup(
     classifiers=[
         "Programming Language :: Python :: 3",
     ],
-    python_requires=">=3.11",            # 対応するPythonバージョン
+    python_requires=">=3.7",            # 対応するPythonバージョン
 )


### PR DESCRIPTION
Union型を `TypeA | TypeB`のように書くのは、python3.10からなので、以下のような変更を加えた
- 型ヒントは、 `Union[TypeA, TypeB]`と書くようにする
- isinstanceでは、 `isinstance(val, (TypeA, TypeB))`と書くようにする
